### PR TITLE
Reorder map initialization so 'point' is correctly interpreted

### DIFF
--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
@@ -137,11 +137,11 @@ module ActiveRecord
         protected
 
         def initialize_type_map(m)
+          super
           register_class_with_limit m, %r(geometry)i, Type::Spatial
           m.alias_type %r(point)i, 'geometry'
           m.alias_type %r(linestring)i, 'geometry'
           m.alias_type %r(polygon)i, 'geometry'
-          super
         end
 
 


### PR DESCRIPTION
When initializing the type map, the specializations were registered before all of the generic mappings.  

When the base class registered the base mappings,
it registered "int" as (^int).  Later, when it went to look up type 'point',
it would match this, and think that 'point' was an integer.

This changes it so that the specializations are registered after the generic
ones are, so that when it looks up 'point', it finds these specializations,
instead of finding 'int'
