### PR TITLE
Fix type_to_sql signature (rails 5.2 compatible).

### DIFF
--- a/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2spatial_adapter/main_adapter.rb
@@ -76,13 +76,13 @@ module ActiveRecord
         end
 
 
-        def type_to_sql(type_, limit_ = nil, precision_ = nil, scale_ = nil)
+        def type_to_sql(type_, limit: nil, precision: nil, scale: nil, unsigned: nil, **)
           if (info_ = spatial_column_constructor(type_.to_sym))
-            type_ = limit_[:type] || type_ if limit_.is_a?(::Hash)
+            type_ = limit[:type] || type_ if limit.is_a?(::Hash)
             type_ = 'geometry' if type_.to_s == 'spatial'
             type_ = type_.to_s.gsub('_', '').upcase
           end
-          super(type_, limit_, precision_, scale_)
+          super
         end
 
 


### PR DESCRIPTION
Rails 5.1 changed the signature of `type_to_sql`, see https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb. The method is used for activerecord migrations to map ruby column type to mysql native one. So this PR makes the gem compatible with rails 5.1+ migrations
